### PR TITLE
Fixes compile for chisel5

### DIFF
--- a/design/craft/inclusivecache/src/Directory.scala
+++ b/design/craft/inclusivecache/src/Directory.scala
@@ -23,6 +23,7 @@ import org.chipsalliance.cde.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import MetaData._
+import chisel3.experimental.dataview.BundleUpcastable
 import freechips.rocketchip.util.DescribedSRAM
 
 class DirectoryEntry(params: InclusiveCacheParameters) extends InclusiveCacheBundle(params)
@@ -132,7 +133,7 @@ class Directory(params: InclusiveCacheParameters) extends Module
   val hit = hits.orR
 
   io.result.valid := ren2
-  io.result.bits := Mux(hit, Mux1H(hits, ways), Mux(setQuash && (tagMatch || wayMatch), bypass.data, Mux1H(victimWayOH, ways)))
+  io.result.bits.viewAsSupertype(chiselTypeOf(bypass.data)) :<>= Mux(hit, Mux1H(hits, ways), Mux(setQuash && (tagMatch || wayMatch), bypass.data, Mux1H(victimWayOH, ways)))
   io.result.bits.hit := hit || (setQuash && tagMatch && bypass.data.state =/= INVALID)
   io.result.bits.way := Mux(hit, OHToUInt(hits), Mux(setQuash && tagMatch, bypass.way, victimWay))
 

--- a/design/craft/inclusivecache/src/InclusiveCache.scala
+++ b/design/craft/inclusivecache/src/InclusiveCache.scala
@@ -187,6 +187,8 @@ class InclusiveCache(
 
       scheduler.io.in <> in
       out <> scheduler.io.out
+      scheduler.io.ways := DontCare
+      scheduler.io.divs := DontCare
 
       val flushSelect = edgeIn.manager.managers.flatMap(_.address).map(_.contains(flushInAddress)).reduce(_||_)
       when (flushSelect) { flushNoMatch := false.B }

--- a/design/craft/inclusivecache/src/ListBuffer.scala
+++ b/design/craft/inclusivecache/src/ListBuffer.scala
@@ -53,10 +53,10 @@ class ListBuffer[T <: Data](params: ListBufferParameters[T]) extends Module
   val freeOH = ~(leftOR(~used) << 1) & ~used
   val freeIdx = OHToUInt(freeOH)
 
-  val valid_set = Wire(0.U(params.queues.W))
-  val valid_clr = Wire(0.U(params.queues.W))
-  val used_set  = Wire(0.U(params.entries.W))
-  val used_clr  = Wire(0.U(params.entries.W))
+  val valid_set = WireDefault(0.U(params.queues.W))
+  val valid_clr = WireDefault(0.U(params.queues.W))
+  val used_set  = WireDefault(0.U(params.entries.W))
+  val used_clr  = WireDefault(0.U(params.entries.W))
 
   val push_tail = tail.read(io.push.bits.index)
   val push_valid = valid(io.push.bits.index)

--- a/design/craft/inclusivecache/src/MSHR.scala
+++ b/design/craft/inclusivecache/src/MSHR.scala
@@ -25,6 +25,7 @@ import TLPermissions._
 import TLMessages._
 import MetaData._
 import chisel3.PrintableHelper
+import chisel3.experimental.dataview.BundleUpcastable
 
 class ScheduleRequest(params: InclusiveCacheParameters) extends InclusiveCacheBundle(params)
 {
@@ -293,9 +294,9 @@ class MSHR(params: InclusiveCacheParameters) extends Module
   io.schedule.bits.c.bits.set     := request.set
   io.schedule.bits.c.bits.way     := meta.way
   io.schedule.bits.c.bits.dirty   := meta.dirty
-  io.schedule.bits.d.bits         := request
+  io.schedule.bits.d.bits.viewAsSupertype(chiselTypeOf(request)) :<>= request
   io.schedule.bits.d.bits.param   := Mux(!req_acquire, request.param,
-                                       MuxLookup(request.param, Wire(request.param), Seq(
+                                       MuxLookup(request.param, request.param, Seq(
                                          NtoB -> Mux(req_promoteT, NtoT, NtoB),
                                          BtoT -> Mux(honour_BtoT,  BtoT, NtoT),
                                          NtoT -> NtoT)))
@@ -310,7 +311,7 @@ class MSHR(params: InclusiveCacheParameters) extends Module
 
   // Coverage of state transitions
   def cacheState(entry: DirectoryEntry, hit: Bool) = {
-    val out = Wire(UInt())
+    val out = WireDefault(0.U)
     val c = entry.clients.orR
     val d = entry.dirty
     switch (entry.state) {
@@ -529,7 +530,7 @@ class MSHR(params: InclusiveCacheParameters) extends Module
   }
 
   when (io.allocate.valid) {
-    assert (!request_valid || (no_wait && io.schedule.fire()))
+    assert (!request_valid || (no_wait && io.schedule.fire))
     request_valid := true.B
     request := io.allocate.bits
   }

--- a/design/craft/inclusivecache/src/SinkC.scala
+++ b/design/craft/inclusivecache/src/SinkC.scala
@@ -88,7 +88,7 @@ class SinkC(params: InclusiveCacheParameters) extends Module
 
     // Cut path from inner C to the BankedStore SRAM setup
     //   ... this makes it easier to layout the L2 data banks far away
-    val bs_adr = Wire(io.bs_adr)
+    val bs_adr = Wire(chiselTypeOf(io.bs_adr))
     io.bs_adr <> Queue(bs_adr, 1, pipe=true)
     io.bs_dat.data   := RegEnable(c.bits.data,    bs_adr.fire)
     bs_adr.valid     := resp && (!first || (c.valid && hasData))

--- a/design/craft/inclusivecache/src/SinkX.scala
+++ b/design/craft/inclusivecache/src/SinkX.scala
@@ -50,4 +50,5 @@ class SinkX(params: InclusiveCacheParameters) extends Module
   io.req.bits.offset := 0.U
   io.req.bits.set    := set
   io.req.bits.tag    := tag
+  io.req.bits.put    := 0.U
 }

--- a/design/craft/inclusivecache/src/SourceA.scala
+++ b/design/craft/inclusivecache/src/SourceA.scala
@@ -40,7 +40,7 @@ class SourceA(params: InclusiveCacheParameters) extends Module
   // ready must be a register, because we derive valid from ready
   require (!params.micro.outerBuf.a.pipe && params.micro.outerBuf.a.isDefined)
 
-  val a = Wire(io.a)
+  val a = Wire(chiselTypeOf(io.a))
   io.a <> params.micro.outerBuf.a(a)
 
   io.req.ready := a.ready
@@ -54,4 +54,5 @@ class SourceA(params: InclusiveCacheParameters) extends Module
   a.bits.address := params.expandAddress(io.req.bits.tag, io.req.bits.set, 0.U)
   a.bits.mask    := ~0.U(params.outer.manager.beatBytes.W)
   a.bits.data    := 0.U
+  a.bits.corrupt := false.B
 }

--- a/design/craft/inclusivecache/src/SourceB.scala
+++ b/design/craft/inclusivecache/src/SourceB.scala
@@ -61,7 +61,7 @@ class SourceB(params: InclusiveCacheParameters) extends Module
     when (io.req.fire) { remain_set := io.req.bits.clients }
 
     // No restrictions on the type of buffer used here
-    val b = Wire(io.b)
+    val b = Wire(chiselTypeOf(io.b))
     io.b <> params.micro.innerBuf.b(b)
 
     b.valid := busy || io.req.valid
@@ -79,5 +79,6 @@ class SourceB(params: InclusiveCacheParameters) extends Module
     b.bits.address := params.expandAddress(tag, set, 0.U)
     b.bits.mask    := ~0.U(params.inner.manager.beatBytes.W)
     b.bits.data    := 0.U
+    b.bits.corrupt := false.B
   }
 }

--- a/design/craft/inclusivecache/src/SourceC.scala
+++ b/design/craft/inclusivecache/src/SourceC.scala
@@ -51,7 +51,7 @@ class SourceC(params: InclusiveCacheParameters) extends Module
   val beatBytes = params.outer.manager.beatBytes
   val beats = params.cache.blockBytes / beatBytes
   val flow = params.micro.outerBuf.c.flow
-  val queue = Module(new Queue(io.c.bits, beats + 3 + (if (flow) 0 else 1), flow = flow))
+  val queue = Module(new Queue(chiselTypeOf(io.c.bits), beats + 3 + (if (flow) 0 else 1), flow = flow))
 
   // queue.io.count is far too slow
   val fillBits = log2Up(beats + 4)
@@ -102,7 +102,7 @@ class SourceC(params: InclusiveCacheParameters) extends Module
   val s3_beat = RegEnable(s2_beat, s3_latch)
   val s3_last = RegEnable(s2_last, s3_latch)
 
-  val c = Wire(io.c)
+  val c = Wire(chiselTypeOf(io.c))
   c.valid        := s3_valid
   c.bits.opcode  := s3_req.opcode
   c.bits.param   := s3_req.param

--- a/design/craft/inclusivecache/src/SourceD.scala
+++ b/design/craft/inclusivecache/src/SourceD.scala
@@ -117,7 +117,7 @@ class SourceD(params: InclusiveCacheParameters) extends Module
   params.ccover(io.bs_radr.valid && !io.bs_radr.ready, "SOURCED_1_READ_STALL", "Data readout stalled")
 
   // Make a queue to catch BS readout during stalls
-  val queue = Module(new Queue(io.bs_rdat, 3, flow=true))
+  val queue = Module(new Queue(chiselTypeOf(io.bs_rdat), 3, flow=true))
   queue.io.enq.valid := RegNext(RegNext(io.bs_radr.fire))
   queue.io.enq.bits := io.bs_rdat
   assert (!queue.io.enq.valid || queue.io.enq.ready)
@@ -215,7 +215,7 @@ class SourceD(params: InclusiveCacheParameters) extends Module
   val resp_opcode = VecInit(Seq(AccessAck, AccessAck, AccessAckData, AccessAckData, AccessAckData, HintAck, grant, Grant))
 
   // No restrictions on the type of buffer used here
-  val d = Wire(io.d)
+  val d = Wire(chiselTypeOf(io.d))
   io.d <> params.micro.innerBuf.d(d)
 
   d.valid := s3_valid_d
@@ -264,6 +264,7 @@ class SourceD(params: InclusiveCacheParameters) extends Module
   atomics.io.a.address := 0.U
   atomics.io.a.mask    := s4_pdata.mask
   atomics.io.a.data    := s4_pdata.data
+  atomics.io.a.corrupt := DontCare
   atomics.io.data_in   := s4_rdata
 
   io.bs_wadr.valid := s4_full && s4_need_bs

--- a/design/craft/inclusivecache/src/SourceE.scala
+++ b/design/craft/inclusivecache/src/SourceE.scala
@@ -36,7 +36,7 @@ class SourceE(params: InclusiveCacheParameters) extends Module
   // ready must be a register, because we derive valid from ready
   require (!params.micro.outerBuf.e.pipe && params.micro.outerBuf.e.isDefined)
 
-  val e = Wire(io.e)
+  val e = Wire(chiselTypeOf(io.e))
   io.e <> params.micro.outerBuf.e(e)
 
   io.req.ready := e.ready

--- a/design/craft/inclusivecache/src/SourceX.scala
+++ b/design/craft/inclusivecache/src/SourceX.scala
@@ -33,7 +33,7 @@ class SourceX(params: InclusiveCacheParameters) extends Module
     val x = Decoupled(new SourceXRequest(params))
   })
 
-  val x = Wire(io.x) // ready must not depend on valid
+  val x = Wire(chiselTypeOf(io.x)) // ready must not depend on valid
   io.x <> Queue(x, 1)
 
   io.req.ready := x.ready


### PR DESCRIPTION
It can be compiled and emit verilog with this command after:
```
nix develop -c mill -i 'playground.verilog'
```
in the https://github.com/chipsalliance/playground/commit/dc0a8c602069842ba07c5f948de384eeb2ba119c