### PR TITLE
Update deprecated Chisel APIs

### DIFF
--- a/design/craft/inclusivecache/src/MSHR.scala
+++ b/design/craft/inclusivecache/src/MSHR.scala
@@ -19,7 +19,7 @@ package sifive.blocks.inclusivecache
 
 import chisel3._
 import chisel3.util._
-import chisel3.internal.sourceinfo.SourceInfo
+import chisel3.experimental.SourceInfo
 import freechips.rocketchip.tilelink._
 import TLPermissions._
 import TLMessages._
@@ -237,7 +237,7 @@ class MSHR(params: InclusiveCacheParameters) extends Module
     final_meta_writeback.state := Mux(req_needT,
                                     Mux(req_acquire, TRUNK, TIP),
                                     Mux(!meta.hit, Mux(gotT, Mux(req_acquire, TRUNK, TIP), BRANCH),
-                                      MuxLookup(meta.state, 0.U(2.W), Seq(
+                                      MuxLookup(meta.state, 0.U(2.W))(Seq(
                                         INVALID -> BRANCH,
                                         BRANCH  -> BRANCH,
                                         TRUNK   -> TIP,
@@ -296,7 +296,7 @@ class MSHR(params: InclusiveCacheParameters) extends Module
   io.schedule.bits.c.bits.dirty   := meta.dirty
   io.schedule.bits.d.bits.viewAsSupertype(chiselTypeOf(request)) := request
   io.schedule.bits.d.bits.param   := Mux(!req_acquire, request.param,
-                                       MuxLookup(request.param, request.param, Seq(
+                                       MuxLookup(request.param, request.param)(Seq(
                                          NtoB -> Mux(req_promoteT, NtoT, NtoB),
                                          BtoT -> Mux(honour_BtoT,  BtoT, NtoT),
                                          NtoT -> NtoT)))

--- a/design/craft/inclusivecache/src/Parameters.scala
+++ b/design/craft/inclusivecache/src/Parameters.scala
@@ -19,7 +19,7 @@ package sifive.blocks.inclusivecache
 
 import chisel3._
 import chisel3.util._
-import chisel3.internal.sourceinfo.SourceInfo
+import chisel3.experimental.SourceInfo
 import org.chipsalliance.cde.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._


### PR DESCRIPTION
These have been deprecated since Chisel 3.6.0. They are being removed in Chisel 6, and will become compile errors at that point.

To _actually_ be compatible with Chisel 6, we'll also need the changes from https://github.com/chipsalliance/rocket-chip-inclusive-cache/pull/22, but I'm not sure what the status of that PR is.