### PR TITLE
Cache Control Invalidate Feature

### DIFF
--- a/design/craft/inclusivecache/src/InclusiveCache.scala
+++ b/design/craft/inclusivecache/src/InclusiveCache.scala
@@ -144,6 +144,7 @@ class InclusiveCache(
       // Tie down default values in case there is no controller
       scheduler.io.req.valid := false.B
       scheduler.io.req.bits.address := 0.U
+      scheduler.io.req.bits.invalidate := false.B
       scheduler.io.resp.ready := true.B
 
 
@@ -171,6 +172,7 @@ class InclusiveCache(
 
         sched.io.req.valid := contained && ctrl.module.io.flush_req.valid
         sched.io.req.bits.address := ctrl.module.io.flush_req.bits
+        sched.io.req.bits.invalidate := ctrl.module.io.invalidate_req
         when (contained && sched.io.req.ready) { ctrl.module.io.flush_req.ready := true.B }
 
         when (sched.io.resp.valid) { ctrl.module.io.flush_resp := true.B }

--- a/design/craft/inclusivecache/src/MSHR.scala
+++ b/design/craft/inclusivecache/src/MSHR.scala
@@ -183,10 +183,10 @@ class MSHR(params: InclusiveCacheParameters) extends Module
   val no_wait = w_rprobeacklast && w_releaseack && w_grantlast && w_pprobeacklast && w_grantack
   io.schedule.bits.a.valid := !s_acquire && s_release && s_pprobe
   io.schedule.bits.b.valid := !s_rprobe || !s_pprobe
-  io.schedule.bits.c.valid := (!s_release && w_rprobeackfirst && !request.control(1)) || (!s_probeack && w_pprobeackfirst)
+  io.schedule.bits.c.valid := (!s_release && w_rprobeackfirst && !request.control.invalidate) || (!s_probeack && w_pprobeackfirst)
   io.schedule.bits.d.valid := !s_execute && w_pprobeack && w_grant
   io.schedule.bits.e.valid := !s_grantack && w_grantfirst
-  io.schedule.bits.x.valid := (!s_flush && w_releaseack && !request.control(1)) || (!s_flush && s_release && request.control(1))
+  io.schedule.bits.x.valid := (!s_flush && w_releaseack && !request.control.invalidate) || (!s_flush && s_release && request.control.invalidate)
   io.schedule.bits.dir.valid := (!s_release && w_rprobeackfirst) || (!s_writeback && no_wait)
   io.schedule.bits.reload := no_wait
   io.schedule.valid := io.schedule.bits.a.valid || io.schedule.bits.b.valid || io.schedule.bits.c.valid ||
@@ -195,16 +195,16 @@ class MSHR(params: InclusiveCacheParameters) extends Module
 
   // Schedule completions
   when (io.schedule.ready) {
-                                                 s_rprobe     := true.B
-    when (w_rprobeackfirst)                    { s_release    := true.B }
-                                                 s_pprobe     := true.B
-    when (s_release && s_pprobe)               { s_acquire    := true.B }
-    when (w_releaseack && !request.control(1)) { s_flush      := true.B }
-    when (s_release && request.control(1))     { s_flush      := true.B }
-    when (w_pprobeackfirst)                    { s_probeack   := true.B }
-    when (w_grantfirst)                        { s_grantack   := true.B }
-    when (w_pprobeack && w_grant)              { s_execute    := true.B }
-    when (no_wait)                             { s_writeback  := true.B }
+                                                         s_rprobe     := true.B
+    when (w_rprobeackfirst)                            { s_release    := true.B }
+                                                         s_pprobe     := true.B
+    when (s_release && s_pprobe)                       { s_acquire    := true.B }
+    when (w_releaseack && !request.control.invalidate) { s_flush      := true.B }
+    when (s_release && request.control.invalidate)     { s_flush      := true.B }
+    when (w_pprobeackfirst)                            { s_probeack   := true.B }
+    when (w_grantfirst)                                { s_grantack   := true.B }
+    when (w_pprobeack && w_grant)                      { s_execute    := true.B }
+    when (no_wait)                                     { s_writeback  := true.B }
     // Await the next operation
     when (no_wait) {
       request_valid := false.B
@@ -226,7 +226,7 @@ class MSHR(params: InclusiveCacheParameters) extends Module
     final_meta_writeback.state   := Mux(request.param =/= TtoT && meta.state === TRUNK, TIP, meta.state)
     final_meta_writeback.clients := meta.clients & ~Mux(isToN(request.param), req_clientBit, 0.U)
     final_meta_writeback.hit     := true.B // chained requests are hits
-  } .elsewhen (request.control(0) && params.control.B) { // request.prio(0)
+  } .elsewhen (request.control.flush && params.control.B) { // request.prio(0)
     when (meta.hit) {
       final_meta_writeback.dirty   := false.B
       final_meta_writeback.state   := INVALID
@@ -586,13 +586,13 @@ class MSHR(params: InclusiveCacheParameters) extends Module
       assert (new_meta.hit)
     }
     // For X channel requests (ie: flush or invalidate)
-    .elsewhen (new_request.control(0) && params.control.B) { // new_request.prio(0)
+    .elsewhen (new_request.control.flush && params.control.B) { // new_request.prio(0)
       s_flush := false.B
       // Do we need to actually do something?
       when (new_meta.hit) {
         s_release := false.B
         // If flush request is an invalidate, don't writeback cache block. Just clear directory
-        w_releaseack := Mux(new_request.control(1), true.B, false.B)
+        w_releaseack := Mux(new_request.control.invalidate, true.B, false.B)
         // Do we need to shoot-down inner caches?
         when ((!params.firstLevel).B && (new_meta.clients =/= 0.U)) {
           s_rprobe := false.B

--- a/design/craft/inclusivecache/src/QueuedRequest.scala
+++ b/design/craft/inclusivecache/src/QueuedRequest.scala
@@ -21,8 +21,11 @@ import chisel3._
 
 class QueuedRequest(params: InclusiveCacheParameters) extends InclusiveCacheBundle(params)
 {
-  val prio   = Vec(3, Bool()) // A=001, B=010, C=100
-  val control= Vec(2, Bool()) // control command (Flush=01, Invalidate=10)
+  val prio    = Vec(3, Bool()) // A=001, B=010, C=100
+  val control = new Bundle {
+    val flush      = Bool()
+    val invalidate = Bool()
+  }
   val opcode = UInt(3.W)
   val param  = UInt(3.W)
   val size   = UInt(params.inner.bundle.sizeBits.W)

--- a/design/craft/inclusivecache/src/QueuedRequest.scala
+++ b/design/craft/inclusivecache/src/QueuedRequest.scala
@@ -22,7 +22,7 @@ import chisel3._
 class QueuedRequest(params: InclusiveCacheParameters) extends InclusiveCacheBundle(params)
 {
   val prio   = Vec(3, Bool()) // A=001, B=010, C=100
-  val control= Bool() // control command
+  val control= Vec(2, Bool()) // control command (Flush=01, Invalidate=10)
   val opcode = UInt(3.W)
   val param  = UInt(3.W)
   val size   = UInt(params.inner.bundle.sizeBits.W)

--- a/design/craft/inclusivecache/src/SinkA.scala
+++ b/design/craft/inclusivecache/src/SinkA.scala
@@ -83,16 +83,17 @@ class SinkA(params: InclusiveCacheParameters) extends Module
   val (tag, set, offset) = params.parseAddress(a.bits.address)
   val put = Mux(first, freeIdx, RegEnable(freeIdx, first))
 
-  io.req.bits.prio   := VecInit(1.U(3.W).asBools)
-  io.req.bits.control:= VecInit(0.U(2.W).asBools)
-  io.req.bits.opcode := a.bits.opcode
-  io.req.bits.param  := a.bits.param
-  io.req.bits.size   := a.bits.size
-  io.req.bits.source := a.bits.source
-  io.req.bits.offset := offset
-  io.req.bits.set    := set
-  io.req.bits.tag    := tag
-  io.req.bits.put    := put
+  io.req.bits.prio               := VecInit(1.U(3.W).asBools)
+  io.req.bits.control.flush      := false.B
+  io.req.bits.control.invalidate := false.B
+  io.req.bits.opcode             := a.bits.opcode
+  io.req.bits.param              := a.bits.param
+  io.req.bits.size               := a.bits.size
+  io.req.bits.source             := a.bits.source
+  io.req.bits.offset             := offset
+  io.req.bits.set                := set
+  io.req.bits.tag                := tag
+  io.req.bits.put                := put
 
   putbuffer.io.push.bits.index := put
   putbuffer.io.push.bits.data.data    := a.bits.data

--- a/design/craft/inclusivecache/src/SinkA.scala
+++ b/design/craft/inclusivecache/src/SinkA.scala
@@ -84,7 +84,7 @@ class SinkA(params: InclusiveCacheParameters) extends Module
   val put = Mux(first, freeIdx, RegEnable(freeIdx, first))
 
   io.req.bits.prio   := VecInit(1.U(3.W).asBools)
-  io.req.bits.control:= false.B
+  io.req.bits.control:= VecInit(0.U(2.W).asBools)
   io.req.bits.opcode := a.bits.opcode
   io.req.bits.param  := a.bits.param
   io.req.bits.size   := a.bits.size

--- a/design/craft/inclusivecache/src/SinkC.scala
+++ b/design/craft/inclusivecache/src/SinkC.scala
@@ -139,16 +139,17 @@ class SinkC(params: InclusiveCacheParameters) extends Module
 
     val put = Mux(first, freeIdx, RegEnable(freeIdx, first))
 
-    io.req.bits.prio   := VecInit(4.U(3.W).asBools)
-    io.req.bits.control:= VecInit(0.U(2.W).asBools)
-    io.req.bits.opcode := c.bits.opcode
-    io.req.bits.param  := c.bits.param
-    io.req.bits.size   := c.bits.size
-    io.req.bits.source := c.bits.source
-    io.req.bits.offset := offset
-    io.req.bits.set    := set
-    io.req.bits.tag    := tag
-    io.req.bits.put    := put
+    io.req.bits.prio               := VecInit(4.U(3.W).asBools)
+    io.req.bits.control.flush      := false.B
+    io.req.bits.control.invalidate := false.B
+    io.req.bits.opcode             := c.bits.opcode
+    io.req.bits.param              := c.bits.param
+    io.req.bits.size               := c.bits.size
+    io.req.bits.source             := c.bits.source
+    io.req.bits.offset             := offset
+    io.req.bits.set                := set
+    io.req.bits.tag                := tag
+    io.req.bits.put                := put
 
     putbuffer.io.push.bits.index := put
     putbuffer.io.push.bits.data.data    := c.bits.data

--- a/design/craft/inclusivecache/src/SinkC.scala
+++ b/design/craft/inclusivecache/src/SinkC.scala
@@ -140,7 +140,7 @@ class SinkC(params: InclusiveCacheParameters) extends Module
     val put = Mux(first, freeIdx, RegEnable(freeIdx, first))
 
     io.req.bits.prio   := VecInit(4.U(3.W).asBools)
-    io.req.bits.control:= false.B
+    io.req.bits.control:= VecInit(0.U(2.W).asBools)
     io.req.bits.opcode := c.bits.opcode
     io.req.bits.param  := c.bits.param
     io.req.bits.size   := c.bits.size

--- a/design/craft/inclusivecache/src/SinkX.scala
+++ b/design/craft/inclusivecache/src/SinkX.scala
@@ -40,16 +40,17 @@ class SinkX(params: InclusiveCacheParameters) extends Module
   io.req.valid := x.valid
   params.ccover(x.valid && !x.ready, "SINKX_STALL", "Backpressure when accepting a control message")
 
-  io.req.bits.prio   := VecInit(1.U(3.W).asBools) // same prio as A
-  io.req.bits.control:= Mux(x.bits.invalidate, VecInit(3.U(2.W).asBools), VecInit(1.U(2.W).asBools))
-  io.req.bits.opcode := 0.U
-  io.req.bits.param  := 0.U
-  io.req.bits.size   := params.offsetBits.U
+  io.req.bits.prio               := VecInit(1.U(3.W).asBools) // same prio as A
+  io.req.bits.control.flush      := true.B
+  io.req.bits.control.invalidate := x.bits.invalidate
+  io.req.bits.opcode             := 0.U
+  io.req.bits.param              := 0.U
+  io.req.bits.size               := params.offsetBits.U
   // The source does not matter, because a flush command never allocates a way.
   // However, it must be a legal source, otherwise assertions might spuriously fire.
-  io.req.bits.source := params.inner.client.clients.map(_.sourceId.start).min.U
-  io.req.bits.offset := 0.U
-  io.req.bits.set    := set
-  io.req.bits.tag    := tag
-  io.req.bits.put    := 0.U
+  io.req.bits.source             := params.inner.client.clients.map(_.sourceId.start).min.U
+  io.req.bits.offset             := 0.U
+  io.req.bits.set                := set
+  io.req.bits.tag                := tag
+  io.req.bits.put                := 0.U
 }

--- a/design/craft/inclusivecache/src/SinkX.scala
+++ b/design/craft/inclusivecache/src/SinkX.scala
@@ -23,6 +23,7 @@ import chisel3.util._
 class SinkXRequest(params: InclusiveCacheParameters) extends InclusiveCacheBundle(params)
 {
   val address = UInt(params.inner.bundle.addressBits.W)
+  val invalidate = Bool()
 }
 
 class SinkX(params: InclusiveCacheParameters) extends Module
@@ -40,7 +41,7 @@ class SinkX(params: InclusiveCacheParameters) extends Module
   params.ccover(x.valid && !x.ready, "SINKX_STALL", "Backpressure when accepting a control message")
 
   io.req.bits.prio   := VecInit(1.U(3.W).asBools) // same prio as A
-  io.req.bits.control:= true.B
+  io.req.bits.control:= Mux(x.bits.invalidate, VecInit(3.U(2.W).asBools), VecInit(1.U(2.W).asBools))
   io.req.bits.opcode := 0.U
   io.req.bits.param  := 0.U
   io.req.bits.size   := params.offsetBits.U


### PR DESCRIPTION
This is a new invalidate feature inside the last-level cache controller. I thought this would be a useful feature given there is a flush version of it. The invalidate feature uses a lot of the already supported flush functionality, but does not allow the write back of the cache block to main memory.

Any comments/feedback are much appreciated!