### PR TITLE
Add TL crossing between cbus and control ports

### DIFF
--- a/design/craft/inclusivecache/src/Configs.scala
+++ b/design/craft/inclusivecache/src/Configs.scala
@@ -24,6 +24,7 @@ import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
 import sifive.blocks.inclusivecache._
 import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.prci.{ClockCrossingType, NoCrossing}
 import freechips.rocketchip.util._
 import sifive.blocks.inclusivecache.InclusiveCacheParameters
 
@@ -37,6 +38,7 @@ case class InclusiveCacheParams(
   hintsSkipProbe: Boolean = false, // do hints probe the same client
   bankedControl: Boolean = false, // bank the cache ctrl with the cache banks
   ctrlAddr: Option[Int] = Some(InclusiveCacheParameters.L2ControlAddress),
+  ctrlXType: ClockCrossingType = NoCrossing, // crossing between cbus and the L2's (sbus-clocked) control ports
   // Interior/Exterior refer to placement either inside the Scheduler or outside it
   // Inner/Outer refer to buffers on the front (towards cores) or back (towards DDR) of the L2
   bufInnerInterior: InclusiveCachePortParameters = InclusiveCachePortParameters.fullC,
@@ -54,6 +56,7 @@ class WithInclusiveCache(
   hintsSkipProbe: Boolean = false,
   bankedControl: Boolean = false,
   ctrlAddr: Option[Int] = Some(InclusiveCacheParameters.L2ControlAddress),
+  ctrlXType: ClockCrossingType = NoCrossing,
   writeBytes: Int = 8
 ) extends Config((site, here, up) => {
   case InclusiveCacheKey => InclusiveCacheParams(
@@ -64,7 +67,8 @@ class WithInclusiveCache(
       portFactor = subBankingFactor,
       hintsSkipProbe = hintsSkipProbe,
       bankedControl = bankedControl,
-      ctrlAddr = ctrlAddr)
+      ctrlAddr = ctrlAddr,
+      ctrlXType = ctrlXType)
   case SubsystemBankedCoherenceKey => up(SubsystemBankedCoherenceKey, site).copy(coherenceManager = { context =>
     implicit val p = context.p
     val sbus = context.tlBusWrapperLocationMap(SBUS)
@@ -79,6 +83,7 @@ class WithInclusiveCache(
       hintsSkipProbe,
       bankedControl,
       ctrlAddr,
+      ctrlXType,
       bufInnerInterior,
       bufInnerExterior,
       bufOuterInterior,
@@ -133,14 +138,16 @@ class WithInclusiveCache(
       case Some(fp) => {
         val physicalFilter = LazyModule(new PhysicalFilter(fp.copy(controlBeatBytes = cbus.beatBytes)))
         lastLevelNode :*= physicalFilter.node :*= l2_outer_buffer.node
-        physicalFilter.controlNode := cbus.coupleTo("physical_filter") {
-          TLBuffer(1) := TLFragmenter(cbus, Some("LLCPhysicalFilter")) := _
+        physicalFilter.controlNode := LazyScope("physical_filter_xing", "TLPhysicalFilterCtrlCrossing") {
+          TLBuffer(1) := TLFragmenter(cbus, Some("LLCPhysicalFilter")) := cbus.crossOutHelper(ctrlXType)
         }
       }
     }
 
     l2.ctrls.foreach {
-      _.ctrlnode := cbus.coupleTo("l2_ctrl") { TLBuffer(1) := TLFragmenter(cbus, Some("LLCCtrl")) := _ }
+      _.ctrlnode := LazyScope("l2_ctrl_xing", "TLL2CtrlCrossing") {
+        TLBuffer(1) := TLFragmenter(cbus, Some("LLCCtrl")) := cbus.crossOutHelper(ctrlXType)
+      }
     }
 
     ElaborationArtefacts.add("l2.json", l2.module.json)


### PR DESCRIPTION
Resolves issue #9.

To test this in Chipyard, you can add this code to `generators/chipyard/src/main/scala/config/fragments/SubsystemFragments.scala`:

```scala
// Customize the control crossing of the inclusive LLC. The LLC runs on the sbus domain, and the
// two control ports are driven by the cbus. Defaults to whatever crossing is already configured
// between sbus and cbus.
class WithInclusiveCacheCtrlCrossingType(xType: Option[ClockCrossingType] = None) extends Config((site, here, up) => {
  case InclusiveCacheKey => up(InclusiveCacheKey).copy(ctrlXType = xType.getOrElse(site(SbusToCbusXTypeKey)))
})
```