### PR TITLE
Resolve implicit-width-truncation warnings

### DIFF
--- a/design/craft/inclusivecache/src/InclusiveCache.scala
+++ b/design/craft/inclusivecache/src/InclusiveCache.scala
@@ -171,7 +171,7 @@ class InclusiveCache(
         when (contained) { ctrl.module.io.flush_match := true.B }
 
         sched.io.req.valid := contained && ctrl.module.io.flush_req.valid
-        sched.io.req.bits.address := ctrl.module.io.flush_req.bits
+        sched.io.req.bits.address :<= ctrl.module.io.flush_req.bits.squeeze
         sched.io.req.bits.invalidate := ctrl.module.io.invalidate_req
         when (contained && sched.io.req.ready) { ctrl.module.io.flush_req.ready := true.B }
 

--- a/design/craft/inclusivecache/src/ListBuffer.scala
+++ b/design/craft/inclusivecache/src/ListBuffer.scala
@@ -51,7 +51,7 @@ class ListBuffer[T <: Data](params: ListBufferParameters[T]) extends Module
   val next  = Mem(params.entries, UInt(params.entryBits.W))
   val data  = Mem(params.entries, params.gen)
 
-  val freeOH = ~(leftOR(~used) << 1) & ~used
+  val freeOH = (~(leftOR(~used) << 1) & ~used)(params.entries-1, 0)
   val freeIdx = OHToUInt(freeOH)
 
   val valid_set = WireDefault(0.U(params.queues.W))
@@ -65,7 +65,7 @@ class ListBuffer[T <: Data](params: ListBufferParameters[T]) extends Module
   io.push.ready := !used.andR
   when (io.push.fire) {
     valid_set := UIntToOH(io.push.bits.index, params.queues)
-    used_set := freeOH
+    used_set :<= freeOH
     data.write(freeIdx, io.push.bits.data)
     when (push_valid) {
       next.write(push_tail, freeIdx)

--- a/design/craft/inclusivecache/src/SinkA.scala
+++ b/design/craft/inclusivecache/src/SinkA.scala
@@ -56,7 +56,7 @@ class SinkA(params: InclusiveCacheParameters) extends Module
   lists := (lists | lists_set) & ~lists_clr
 
   val free = !lists.andR
-  val freeOH = ~(leftOR(~lists) << 1) & ~lists
+  val freeOH = (~(leftOR(~lists) << 1) & ~lists)(params.putLists-1, 0)
   val freeIdx = OHToUInt(freeOH)
 
   val first = params.inner.first(a)
@@ -78,7 +78,7 @@ class SinkA(params: InclusiveCacheParameters) extends Module
   a.ready := !req_block && !buf_block && !set_block
   io.req.valid := a.valid && first && !buf_block && !set_block
   putbuffer.io.push.valid := a.valid && hasData && !req_block && !set_block
-  when (a.valid && first && hasData && !req_block && !buf_block) { lists_set := freeOH }
+  when (a.valid && first && hasData && !req_block && !buf_block) { lists_set :<= freeOH }
 
   val (tag, set, offset) = params.parseAddress(a.bits.address)
   val put = Mux(first, freeIdx, RegEnable(freeIdx, first))

--- a/design/craft/inclusivecache/src/SinkC.scala
+++ b/design/craft/inclusivecache/src/SinkC.scala
@@ -120,7 +120,7 @@ class SinkC(params: InclusiveCacheParameters) extends Module
     lists := (lists | lists_set) & ~lists_clr
 
     val free = !lists.andR
-    val freeOH = ~(leftOR(~lists) << 1) & ~lists
+    val freeOH = (~(leftOR(~lists) << 1) & ~lists)(params.relLists-1, 0)
     val freeIdx = OHToUInt(freeOH)
 
     val req_block = first && !io.req.ready
@@ -135,7 +135,7 @@ class SinkC(params: InclusiveCacheParameters) extends Module
 
     io.req.valid := !resp && c.valid && first && !buf_block && !set_block
     putbuffer.io.push.valid := !resp && c.valid && hasData && !req_block && !set_block
-    when (!resp && c.valid && first && hasData && !req_block && !buf_block) { lists_set := freeOH }
+    when (!resp && c.valid && first && hasData && !req_block && !buf_block) { lists_set :<= freeOH }
 
     val put = Mux(first, freeIdx, RegEnable(freeIdx, first))
 
@@ -151,7 +151,7 @@ class SinkC(params: InclusiveCacheParameters) extends Module
     io.req.bits.tag                := tag
     io.req.bits.put                := put
 
-    putbuffer.io.push.bits.index := put
+    putbuffer.io.push.bits.index :<= put
     putbuffer.io.push.bits.data.data    := c.bits.data
     putbuffer.io.push.bits.data.corrupt := c.bits.corrupt
 

--- a/design/craft/inclusivecache/src/SinkC.scala
+++ b/design/craft/inclusivecache/src/SinkC.scala
@@ -156,7 +156,7 @@ class SinkC(params: InclusiveCacheParameters) extends Module
     putbuffer.io.push.bits.data.corrupt := c.bits.corrupt
 
     // Grant access to pop the data
-    putbuffer.io.pop.bits := io.rel_pop.bits.index
+    putbuffer.io.pop.bits :<= io.rel_pop.bits.index.squeeze
     putbuffer.io.pop.valid := io.rel_pop.fire
     io.rel_pop.ready := putbuffer.io.valid(io.rel_pop.bits.index(log2Ceil(params.relLists)-1,0))
     io.rel_beat := putbuffer.io.data

--- a/design/craft/inclusivecache/src/SinkD.scala
+++ b/design/craft/inclusivecache/src/SinkD.scala
@@ -75,7 +75,7 @@ class SinkD(params: InclusiveCacheParameters) extends Module
   io.bs_adr.bits.noop := !d.valid || !hasData
   io.bs_adr.bits.way  := io.way
   io.bs_adr.bits.set  := io.set
-  io.bs_adr.bits.beat := Mux(d.valid, beat, RegEnable(beat + io.bs_adr.ready.asUInt, d.valid))
+  io.bs_adr.bits.beat :<= Mux(d.valid, beat, RegEnable(beat + io.bs_adr.ready.asUInt, d.valid)).squeeze
   io.bs_adr.bits.mask := ~0.U(params.outerMaskBits.W)
   io.bs_dat.data      := d.bits.data
 

--- a/design/craft/inclusivecache/src/SourceB.scala
+++ b/design/craft/inclusivecache/src/SourceB.scala
@@ -50,7 +50,7 @@ class SourceB(params: InclusiveCacheParameters) extends Module
 
     val busy = remain.orR
     val todo = Mux(busy, remain, io.req.bits.clients)
-    val next = ~(leftOR(todo) << 1) & todo
+    val next = (~(leftOR(todo) << 1) & todo)(params.clientBits-1, 0)
 
     if (params.clientBits > 1) {
       params.ccover(PopCount(remain) > 1.U, "SOURCEB_MULTI_PROBE", "Had to probe more than one client")
@@ -66,7 +66,7 @@ class SourceB(params: InclusiveCacheParameters) extends Module
     io.b <> params.micro.innerBuf.b(b)
 
     b.valid := busy || io.req.valid
-    when (b.fire) { remain_clr := next }
+    when (b.fire) { remain_clr :<= next }
     params.ccover(b.valid && !b.ready, "SOURCEB_STALL", "Backpressured when issuing a probe")
 
     val tag = Mux(!busy, io.req.bits.tag, RegEnable(io.req.bits.tag, io.req.fire))

--- a/design/craft/inclusivecache/src/SourceB.scala
+++ b/design/craft/inclusivecache/src/SourceB.scala
@@ -74,7 +74,7 @@ class SourceB(params: InclusiveCacheParameters) extends Module
     val param = Mux(!busy, io.req.bits.param, RegEnable(io.req.bits.param, io.req.fire))
 
     b.bits.opcode  := TLMessages.Probe
-    b.bits.param   := param
+    b.bits.param   :<= param.squeeze
     b.bits.size    := params.offsetBits .U
     b.bits.source  := params.clientSource(next)
     b.bits.address := params.expandAddress(tag, set, 0.U)


### PR DESCRIPTION
firtool-1.154.0 and later warn on all implicit width truncations (https://github.com/llvm/circt/pull/10621). These
width truncations were flagged in stock Chipyard builds.

This PR is split into two commits. In the first commit, all of the changes follow this pattern:

For these width truncations, use the equivalent `Connectable` operator
(`:<=`), along with `.squeeze`. This has the same behavior as the
original `:=` connections, since those truncate when the producer in a
connection is wider than the consumer.

In the second commit, all of the changes follow this pattern:

These changes have a different shape from the previous ones. These
bit-slice a variable before it is used in a number of places. Every one
of these bit-slices has the same structure: `~(leftOR(x) << 1) & ~x`.
The width of `leftOR(x)` is always the width of `x`, which means the
width of `leftOR(x) << 1` is always one more than the width of `x`. This
means in the `&` expression, the `~x` will be zero-extended by 1 bit, so
the MSB of the resulting `&` expression is always 0.

That 0-value MSB is used for various one-hot operations, which means it
never impacts those results.

I also ran `eqy` on all of these modules, built from the `RocketConfig`
design in Chipyard, and they all passed.